### PR TITLE
Implement basic search page

### DIFF
--- a/components/Container.js
+++ b/components/Container.js
@@ -1,12 +1,12 @@
 import { Grid } from '@chakra-ui/core';
 
-function Container({ desktopWidth=85, mobileWidth=95, children }) {
+function Container({ desktopWidth=85, mobileWidth=95, leftColumn=60, rightColumn=40, children }) {
 
   const desktop = `${desktopWidth}%`;
   const mobile = `${mobileWidth}%`;
   const responsiveWidth = [mobile, mobile, desktop, desktop];
 
-  const splitColumns = '60% 40%';
+  const splitColumns = `${leftColumn}% ${rightColumn}%`;
   const oneColumn = '100%';
   const responsiveColumns = [oneColumn, oneColumn, oneColumn, splitColumns];
 

--- a/components/ResponsiveHeading.js
+++ b/components/ResponsiveHeading.js
@@ -1,14 +1,16 @@
 import { Heading } from "@chakra-ui/core";
 
-function ResponsiveHeading({ children }) {
+function ResponsiveHeading({ as="h2", size="xl", props, children }) {
   const responsiveAlign = ['center', 'center', 'center', 'left'];
 
   return (
     <Heading
-      as="h2"
+      as={as}
       mb={2}
       mt={4}
+      size={size}
       textAlign={responsiveAlign}
+      {...props}
     >
       {children}
     </Heading>

--- a/components/TagFilterButton.js
+++ b/components/TagFilterButton.js
@@ -1,0 +1,23 @@
+import { useState } from "react";
+import { Button } from "@chakra-ui/core";
+
+function TagFilterButton({ tag, handleChange }) {
+  const [selected, setSelected] = useState(false);
+
+  return (
+    <Button 
+      key={tag.id}
+      onClick={() => {
+        setSelected(!selected);
+        handleChange(tag.id);
+      }}
+      my={1}
+      variant={selected ? 'solid' : 'outline'}
+      variantColor="pink"
+    >
+      {tag.name}
+    </Button>
+  );
+}
+
+export default TagFilterButton;

--- a/fixtures/builds.js
+++ b/fixtures/builds.js
@@ -38,6 +38,7 @@ export const BUILDS = [
       "The best free video tutorials on getting into UI/UX design as a software engineer.",
     builder: "John Doe",
     tagIds: [
+      "7",
       "10",
       "11",
       "12"

--- a/pages/search.js
+++ b/pages/search.js
@@ -1,14 +1,34 @@
-import { Heading } from '@chakra-ui/core';
-import Container from '../components/Container';
-import NavigationBar from '../components/NavigationBar';
+import { Heading, Box } from "@chakra-ui/core";
+import NavigationBar from "../components/NavigationBar";
+import Container from "../components/Container";
+import ResponsiveHeading from "../components/ResponsiveHeading";
+import Builds from "../components/Builds";
+import { fetchBuilds, fetchTags } from "../clients"
 
-export default function Search() {
+export default function Search({ builds, tags }) {
   return (
     <div>
       <NavigationBar />
-      <Container>
-        <Heading>Search</Heading>
+      <Container leftColumn={30} rightColumn={70}>
+        <Box>
+          <ResponsiveHeading>Options</ResponsiveHeading>
+        </Box>
+
+        <Box>
+          <ResponsiveHeading>Search</ResponsiveHeading>
+          <Builds builds={builds} tags={tags} header={''} />
+        </Box>
       </Container>
     </div>
   );
+}
+
+// TODO(Renzo): handle promises once data fetching returns actual data
+export async function getStaticProps() {
+  return {
+    props: {
+      builds: await fetchBuilds(),
+      tags: await fetchTags()
+    },
+  };
 }

--- a/pages/search.js
+++ b/pages/search.js
@@ -1,4 +1,5 @@
-import { Heading, Box } from "@chakra-ui/core";
+import { useState } from "react";
+import { Icon, Input, InputGroup, Box, InputLeftElement } from "@chakra-ui/core";
 import NavigationBar from "../components/NavigationBar";
 import Container from "../components/Container";
 import ResponsiveHeading from "../components/ResponsiveHeading";
@@ -6,6 +7,18 @@ import Builds from "../components/Builds";
 import { fetchBuilds, fetchTags } from "../clients"
 
 export default function Search({ builds, tags }) {
+  const [query, setQuery] = useState('');
+
+  function handleQueryChange(event) {
+    setQuery(event.target.value);
+  }
+
+  function filterBuilds() {
+    return builds.filter(build => (
+      build.name.toLowerCase().includes(query)
+    ));
+  }
+
   return (
     <div>
       <NavigationBar />
@@ -16,7 +29,16 @@ export default function Search({ builds, tags }) {
 
         <Box>
           <ResponsiveHeading>Search</ResponsiveHeading>
-          <Builds builds={builds} tags={tags} header={''} />
+          <InputGroup>
+            <InputLeftElement children={<Icon name="search" color="gray.400" />} />
+            <Input
+              value={query}
+              placeholder="Find a build to learn..."
+              size="lg"
+              onChange={handleQueryChange}  
+            />
+          </InputGroup>
+          <Builds builds={filterBuilds()} tags={tags} header={''} />
         </Box>
       </Container>
     </div>

--- a/pages/search.js
+++ b/pages/search.js
@@ -2,20 +2,28 @@ import { useState } from "react";
 import { Icon, Input, InputGroup, Box, InputLeftElement } from "@chakra-ui/core";
 import NavigationBar from "../components/NavigationBar";
 import Container from "../components/Container";
+import CardComponent from "../components/CardComponent";
 import ResponsiveHeading from "../components/ResponsiveHeading";
 import Builds from "../components/Builds";
 import { fetchBuilds, fetchTags } from "../clients"
 
 export default function Search({ builds, tags }) {
-  const [query, setQuery] = useState('');
+  const [nameQuery, setNameQuery] = useState('');
+  const [builderQuery, setBuilderQuery] = useState('');
 
-  function handleQueryChange(event) {
-    setQuery(event.target.value);
+  function handleNameQueryChange(event) {
+    setNameQuery(event.target.value);
+  }
+
+  function handleBuilderQueryChange(event) {
+    setBuilderQuery(event.target.value);
   }
 
   function filterBuilds() {
     return builds.filter(build => (
-      build.name.toLowerCase().includes(query)
+      build.name.toLowerCase().includes(nameQuery)
+    )).filter(build => (
+      build.builder.toLowerCase().includes(builderQuery)
     ));
   }
 
@@ -25,6 +33,33 @@ export default function Search({ builds, tags }) {
       <Container leftColumn={30} rightColumn={70}>
         <Box>
           <ResponsiveHeading>Options</ResponsiveHeading>
+          <CardComponent>
+            <ResponsiveHeading
+              as={'h4'}
+              size={'md'}
+              props={{mt: 0}}
+            >
+              Filter by builder
+            </ResponsiveHeading>
+
+            <InputGroup>
+              <InputLeftElement children={<Icon name="search" color="gray.400" />} />
+              <Input
+                value={builderQuery}
+                placeholder="Search builder's name here..."
+                size="md"
+                onChange={handleBuilderQueryChange}  
+              />
+            </InputGroup>
+
+            <ResponsiveHeading
+              as={'h4'}
+              size={'md'}
+            >
+              Filter by topic
+            </ResponsiveHeading>
+            
+          </CardComponent>
         </Box>
 
         <Box>
@@ -32,10 +67,10 @@ export default function Search({ builds, tags }) {
           <InputGroup>
             <InputLeftElement children={<Icon name="search" color="gray.400" />} />
             <Input
-              value={query}
+              value={nameQuery}
               placeholder="Find a build to learn..."
               size="lg"
-              onChange={handleQueryChange}  
+              onChange={handleNameQueryChange}  
             />
           </InputGroup>
           <Builds builds={filterBuilds()} tags={tags} header={''} />

--- a/pages/search.js
+++ b/pages/search.js
@@ -1,15 +1,17 @@
 import { useState } from "react";
-import { Icon, Input, InputGroup, Box, InputLeftElement } from "@chakra-ui/core";
+import { Icon, Input, InputGroup, Box, InputLeftElement, Stack } from "@chakra-ui/core";
 import NavigationBar from "../components/NavigationBar";
 import Container from "../components/Container";
 import CardComponent from "../components/CardComponent";
 import ResponsiveHeading from "../components/ResponsiveHeading";
 import Builds from "../components/Builds";
+import TagFilterButton from "../components/TagFilterButton";
 import { fetchBuilds, fetchTags } from "../clients"
 
 export default function Search({ builds, tags }) {
   const [nameQuery, setNameQuery] = useState('');
   const [builderQuery, setBuilderQuery] = useState('');
+  const [tagFilters, setTagFilters] = useState([]);
 
   function handleNameQueryChange(event) {
     setNameQuery(event.target.value);
@@ -19,12 +21,29 @@ export default function Search({ builds, tags }) {
     setBuilderQuery(event.target.value);
   }
 
+  function handleTagFilterChange(tagId) {
+    if (tagFilters.includes(tagId)) {
+      setTagFilters(tagFilters.filter((tagFilter) => (
+        tagFilter !== tagId
+      )));
+    } else {
+      setTagFilters([...tagFilters, tagId]);
+    }
+    console.log(tagFilters);
+  }
+
   function filterBuilds() {
-    return builds.filter(build => (
+    return builds.filter((build) => (
       build.name.toLowerCase().includes(nameQuery)
-    )).filter(build => (
+    )).filter((build) => (
       build.builder.toLowerCase().includes(builderQuery)
-    ));
+    )).filter((build) => {
+      for (let tag of tagFilters) {
+        if (!build.tagIds.some((tagId) => (tagId === tag)))
+          return false;
+      }
+      return true;
+    });
   }
 
   return (
@@ -56,8 +75,17 @@ export default function Search({ builds, tags }) {
               as={'h4'}
               size={'md'}
             >
-              Filter by topic
+              Filter by tag
             </ResponsiveHeading>
+            <Stack>
+              {tags.map(tag => (
+                <TagFilterButton
+                  key={tag.id} 
+                  tag={tag}
+                  handleChange={handleTagFilterChange}
+                />
+              ))}
+            </Stack>
             
           </CardComponent>
         </Box>


### PR DESCRIPTION
## What this pr does
- Shows all current builds in search page
- Implements very basic filtering options for current builds
  - Filter by name (input)
  - Filter by builder/author (input)
  - Filter by all available tags
- Page is fairly mobile friendly (modeled after [egghead.io's search page](https://egghead.io/search))

## Usage
Lets users use the input fields and tag buttons to find specific builds

## Screenshots
### Desktop
![image](https://user-images.githubusercontent.com/55109467/89982767-ef0cdc00-dc3b-11ea-9876-f918c028b60e.png)

### Mobile
![image](https://user-images.githubusercontent.com/55109467/89982865-1e234d80-dc3c-11ea-9717-ade2fe89b4e2.png)

### Example of filtering
![image](https://user-images.githubusercontent.com/55109467/89982920-3a26ef00-dc3c-11ea-840b-c5f3ba708389.png)
